### PR TITLE
Optionally Ignore unknown TrackTypes

### DIFF
--- a/src/Builder/MediaInfoContainerBuilder.php
+++ b/src/Builder/MediaInfoContainerBuilder.php
@@ -6,7 +6,6 @@ use Mhor\MediaInfo\Container\MediaInfoContainer;
 use Mhor\MediaInfo\Factory\AttributeFactory;
 use Mhor\MediaInfo\Factory\TypeFactory;
 use Mhor\MediaInfo\Type\AbstractType;
-use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoContainerBuilder
 {
@@ -45,7 +44,7 @@ class MediaInfoContainerBuilder
     /**
      * @param $typeName
      * @param array $attributes
-     * @throws UnknownTrackTypeException
+     * @throws Mhor\MediaInfo\Exception\UnknownTrackTypeException
      */
     public function addTrackType($typeName, array $attributes)
     {

--- a/src/Builder/MediaInfoContainerBuilder.php
+++ b/src/Builder/MediaInfoContainerBuilder.php
@@ -44,6 +44,7 @@ class MediaInfoContainerBuilder
     /**
      * @param $typeName
      * @param array $attributes
+     * @throws UnknownTrackTypeException
      */
     public function addTrackType($typeName, array $attributes)
     {

--- a/src/Builder/MediaInfoContainerBuilder.php
+++ b/src/Builder/MediaInfoContainerBuilder.php
@@ -6,6 +6,7 @@ use Mhor\MediaInfo\Container\MediaInfoContainer;
 use Mhor\MediaInfo\Factory\AttributeFactory;
 use Mhor\MediaInfo\Factory\TypeFactory;
 use Mhor\MediaInfo\Type\AbstractType;
+use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoContainerBuilder
 {

--- a/src/Container/MediaInfoContainer.php
+++ b/src/Container/MediaInfoContainer.php
@@ -152,9 +152,7 @@ class MediaInfoContainer
                 $this->addOther($trackType);
                 break;
             default:
-                // skip type type rather than wrecking everything
-                // unknown track types are already handled in creation, we shouldn't need to throw anything here
-                break;
+                throw new \Exception('Unknown type');
         }
     }
 

--- a/src/Container/MediaInfoContainer.php
+++ b/src/Container/MediaInfoContainer.php
@@ -129,6 +129,7 @@ class MediaInfoContainer
 
     /**
      * @param  AbstractType $trackType
+     * @throws \Exception
      */
     public function add(AbstractType $trackType)
     {

--- a/src/Container/MediaInfoContainer.php
+++ b/src/Container/MediaInfoContainer.php
@@ -9,7 +9,6 @@ use Mhor\MediaInfo\Type\Image;
 use Mhor\MediaInfo\Type\Subtitle;
 use Mhor\MediaInfo\Type\Video;
 use Mhor\MediaInfo\Type\Other;
-use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoContainer
 {

--- a/src/Container/MediaInfoContainer.php
+++ b/src/Container/MediaInfoContainer.php
@@ -8,6 +8,8 @@ use Mhor\MediaInfo\Type\General;
 use Mhor\MediaInfo\Type\Image;
 use Mhor\MediaInfo\Type\Subtitle;
 use Mhor\MediaInfo\Type\Video;
+use Mhor\MediaInfo\Type\Other;
+use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoContainer
 {
@@ -16,6 +18,7 @@ class MediaInfoContainer
     const IMAGE_CLASS = 'Mhor\MediaInfo\Type\Image';
     const VIDEO_CLASS = 'Mhor\MediaInfo\Type\Video';
     const SUBTITLE_CLASS = 'Mhor\MediaInfo\Type\Subtitle';
+    const OTHER_CLASS = 'Mhor\MediaInfo\Type\Other';
 
     /**
      * @var string
@@ -48,6 +51,11 @@ class MediaInfoContainer
     private $images = array();
 
     /**
+     * @var Other[]
+     */
+    private $others = array();
+
+    /**
      * @return General
      */
     public function getGeneral()
@@ -69,6 +77,14 @@ class MediaInfoContainer
     public function getImages()
     {
         return $this->images;
+    }
+
+    /**
+     * @return Other[]
+     */
+    public function getOthers()
+    {
+        return $this->others;
     }
 
     /**
@@ -113,7 +129,6 @@ class MediaInfoContainer
 
     /**
      * @param  AbstractType $trackType
-     * @throws \Exception
      */
     public function add(AbstractType $trackType)
     {
@@ -133,8 +148,13 @@ class MediaInfoContainer
             case self::SUBTITLE_CLASS:
                 $this->addSubtitle($trackType);
                 break;
+            case self::OTHER_CLASS:
+                $this->addOther($trackType);
+                break;
             default:
-                throw new \Exception('Unknow type');
+                // skip type type rather than wrecking everything
+                // unknown track types are already handled in creation, we shouldn't need to throw anything here
+                break;
         }
     }
 
@@ -168,5 +188,13 @@ class MediaInfoContainer
     private function addSubtitle(Subtitle $subtitle)
     {
         $this->subtitles[] = $subtitle;
+    }
+
+    /**
+     * @param Other $other
+     */
+    private function addOther(Other $other)
+    {
+        $this->others[] = $other;
     }
 }

--- a/src/Exception/UnknownTrackTypeException.php
+++ b/src/Exception/UnknownTrackTypeException.php
@@ -15,7 +15,5 @@ class UnknownTrackTypeException extends \Exception
     public function getTrackType()
     {
         return $this->trackType;
-    } 
+    }
 }
-
-?>

--- a/src/Exception/UnknownTrackTypeException.php
+++ b/src/Exception/UnknownTrackTypeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mhor\MediaInfo\Exception;
+
+class UnknownTrackTypeException extends \Exception
+{
+    private $trackType = null;
+
+    public function __construct($trackType, $code = 0)
+    {
+        parent::__construct(sprintf('Type doesn\'t exist: %s', $trackType), $code, null);
+        $this->trackType = $trackType;
+    }
+
+    public function getTrackType()
+    {
+        return $this->trackType;
+    } 
+}
+
+?>

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -8,6 +8,8 @@ use Mhor\MediaInfo\Type\General;
 use Mhor\MediaInfo\Type\Image;
 use Mhor\MediaInfo\Type\Subtitle;
 use Mhor\MediaInfo\Type\Video;
+use Mhor\MediaInfo\Type\Other;
+use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class TypeFactory
 {
@@ -16,11 +18,12 @@ class TypeFactory
     const GENERAL = 'General';
     const VIDEO = 'Video';
     const SUBTITLE = 'Text';
+    const OTHER = 'Other';
 
     /**
      * @param $type
      * @return AbstractType
-     * @throws \Exception
+     * @throws UnknownTrackTypeException
      */
     public function create($type)
     {
@@ -35,8 +38,10 @@ class TypeFactory
                 return new Video();
             case self::SUBTITLE:
                 return new Subtitle();
+            case self::OTHER:
+               return new Other();
             default:
-                throw new \Exception('Type doesn\'t exist');
+                throw new UnknownTrackTypeException($type);
         }
     }
 }

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -29,19 +29,19 @@ class TypeFactory
     {
         switch ($type) {
             case self::AUDIO:
-                return new Audio();
+            return new Audio();
             case self::IMAGE:
-                return new Image();
+            return new Image();
             case self::GENERAL:
-                return new General();
+            return new General();
             case self::VIDEO:
-                return new Video();
+            return new Video();
             case self::SUBTITLE:
-                return new Subtitle();
+            return new Subtitle();
             case self::OTHER:
-               return new Other();
+            return new Other();
             default:
-                throw new UnknownTrackTypeException($type);
+            throw new UnknownTrackTypeException($type);
         }
     }
 }

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -23,7 +23,7 @@ class TypeFactory
     /**
      * @param $type
      * @return AbstractType
-     * @throws UnknownTrackTypeException
+     * @throws Mhor\MediaInfo\Exception\UnknownTrackTypeException
      */
     public function create($type)
     {

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -29,19 +29,19 @@ class TypeFactory
     {
         switch ($type) {
         case self::AUDIO:
-                return new Audio();
+            return new Audio();
         case self::IMAGE:
-                return new Image();
+            return new Image();
         case self::GENERAL:
-                return new General();
+            return new General();
         case self::VIDEO:
-                return new Video();
+            return new Video();
         case self::SUBTITLE:
-                return new Subtitle();
+            return new Subtitle();
         case self::OTHER:
-                return new Other();
+            return new Other();
         default:
-                throw new UnknownTrackTypeException($type);
+            throw new UnknownTrackTypeException($type);
         }
     }
 }

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -28,20 +28,20 @@ class TypeFactory
     public function create($type)
     {
         switch ($type) {
-        case self::AUDIO:
-            return new Audio();
-        case self::IMAGE:
-            return new Image();
-        case self::GENERAL:
-            return new General();
-        case self::VIDEO:
-            return new Video();
-        case self::SUBTITLE:
-            return new Subtitle();
-        case self::OTHER:
-            return new Other();
-        default:
-            throw new UnknownTrackTypeException($type);
+            case self::AUDIO:
+                return new Audio();
+            case self::IMAGE:
+                return new Image();
+            case self::GENERAL:
+                return new General();
+            case self::VIDEO:
+                return new Video();
+            case self::SUBTITLE:
+                return new Subtitle();
+            case self::OTHER:
+                return new Other();
+            default:
+                throw new UnknownTrackTypeException($type);
         }
     }
 }

--- a/src/Factory/TypeFactory.php
+++ b/src/Factory/TypeFactory.php
@@ -28,20 +28,20 @@ class TypeFactory
     public function create($type)
     {
         switch ($type) {
-            case self::AUDIO:
-            return new Audio();
-            case self::IMAGE:
-            return new Image();
-            case self::GENERAL:
-            return new General();
-            case self::VIDEO:
-            return new Video();
-            case self::SUBTITLE:
-            return new Subtitle();
-            case self::OTHER:
-            return new Other();
-            default:
-            throw new UnknownTrackTypeException($type);
+        case self::AUDIO:
+                return new Audio();
+        case self::IMAGE:
+                return new Image();
+        case self::GENERAL:
+                return new General();
+        case self::VIDEO:
+                return new Video();
+        case self::SUBTITLE:
+                return new Subtitle();
+        case self::OTHER:
+                return new Other();
+        default:
+                throw new UnknownTrackTypeException($type);
         }
     }
 }

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -10,7 +10,8 @@ class MediaInfo
 {
     /**
      * @param $filePath
-     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The default behavior (false) is throw an exception on unknown track types.
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The 
+                                            default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -10,6 +10,7 @@ class MediaInfo
 {
     /**
      * @param $filePath
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -12,7 +12,7 @@ class MediaInfo
      * @param $filePath
      * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The
                                             default behavior (false) is throw an exception on unknown track types.
-     * @throws UnknownTrackTypeException
+     * @throws Mhor\MediaInfo\Exception\UnknownTrackTypeException
      * @return MediaInfoContainer
      */
     public function getInfo($filePath, $ignoreUnknownTrackTypes = false)

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -10,6 +10,7 @@ class MediaInfo
 {
     /**
      * @param $filePath
+     * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */
     public function getInfo($filePath, $ignoreUnknownTrackTypes = false)

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -12,7 +12,7 @@ class MediaInfo
      * @param $filePath
      * @return MediaInfoContainer
      */
-    public function getInfo($filePath)
+    public function getInfo($filePath, $ignoreUnknownTrackTypes = false)
     {
         $mediaInfoCommandBuilder = new MediaInfoCommandBuilder();
         $output = $mediaInfoCommandBuilder->buildMediaInfoCommandRunner($filePath)->run();
@@ -20,6 +20,6 @@ class MediaInfo
         $mediaInfoOutputParser = new MediaInfoOutputParser();
         $mediaInfoOutputParser->parse($output);
 
-        return $mediaInfoOutputParser->getMediaInfoContainer();
+        return $mediaInfoOutputParser->getMediaInfoContainer($ignoreUnknownTrackTypes);
     }
 }

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -10,7 +10,7 @@ class MediaInfo
 {
     /**
      * @param $filePath
-     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The 
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The
                                             default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -22,7 +22,8 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
     }
 
     /**
-     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The default behavior (false) is throw an exception on unknown track types.
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The 
+                                            default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -22,7 +22,7 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
     }
 
     /**
-     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The 
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The
                                             default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -22,6 +22,7 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
     }
 
     /**
+     * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The default behavior (false) is throw an exception on unknown track types.
      * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -22,7 +22,7 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
     }
 
     /**
-     * @throws \Exception
+     * @throws UnknownTrackTypeException
      * @return MediaInfoContainer
      */
     public function getMediaInfoContainer($ignoreUnknownTrackTypes = false)

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -24,7 +24,7 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
     /**
      * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The
                                             default behavior (false) is throw an exception on unknown track types.
-     * @throws UnknownTrackTypeException
+     * @throws Mhor\MediaInfo\Exception\UnknownTrackTypeException
      * @return MediaInfoContainer
      */
     public function getMediaInfoContainer($ignoreUnknownTrackTypes = false)

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -35,14 +35,10 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
         $mediaInfoContainerBuilder->setVersion($this->parsedOutput['@attributes']['version']);
 
         foreach ($this->parsedOutput['File']['track'] as $trackType) {
-            try
-            {
+            try {
                 $mediaInfoContainerBuilder->addTrackType($trackType['@attributes']['type'], $trackType);
-            }
-            catch (UnknownTrackTypeException $ex)
-            {
-                if (!$ignoreUnknownTrackTypes)
-                {
+            } catch (UnknownTrackTypeException $ex) {
+                if (!$ignoreUnknownTrackTypes) {
                     // rethrow exception
                     throw $ex;
                 }

--- a/src/Type/Other.php
+++ b/src/Type/Other.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mhor\MediaInfo\Type;
+
+class Other extends AbstractType
+{
+}

--- a/test/Builder/MediaInfoContainerBuilderTest.php
+++ b/test/Builder/MediaInfoContainerBuilderTest.php
@@ -5,7 +5,6 @@ namespace Mhor\MediaInfo\Test\Builder;
 use Mhor\MediaInfo\Builder\MediaInfoContainerBuilder;
 use Mhor\MediaInfo\Factory\TypeFactory;
 use Mhor\MediaInfo\Type\AbstractType;
-use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class TrackTestType extends AbstractType{}
 
@@ -59,7 +58,7 @@ class MediaInfoContainerBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException UnknownTrackTypeException
+     * @expectedException Mhor\MediaInfo\Exception\UnknownTrackTypeException
      */
     public function testAddInvalidType()
     {

--- a/test/Builder/MediaInfoContainerBuilderTest.php
+++ b/test/Builder/MediaInfoContainerBuilderTest.php
@@ -50,10 +50,15 @@ class MediaInfoContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $mediaContainer = $mediaInfoContainerBuilder->build();
         $subtitles = $mediaContainer->getSubtitles();
         $this->assertEquals(0, count($subtitles[0]->get()));
+
+        $mediaInfoContainerBuilder->addTrackType(TypeFactory::OTHER, array());
+        $mediaContainer = $mediaInfoContainerBuilder->build();
+        $others = $mediaContainer->getOthers();
+        $this->assertEquals(0, count($others[0]->get()));
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException UnknownTrackTypeException
      */
     public function testAddInvalidType()
     {

--- a/test/Builder/MediaInfoContainerBuilderTest.php
+++ b/test/Builder/MediaInfoContainerBuilderTest.php
@@ -5,6 +5,7 @@ namespace Mhor\MediaInfo\Test\Builder;
 use Mhor\MediaInfo\Builder\MediaInfoContainerBuilder;
 use Mhor\MediaInfo\Factory\TypeFactory;
 use Mhor\MediaInfo\Type\AbstractType;
+use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class TrackTestType extends AbstractType{}
 

--- a/test/Parser/MediaInfoOutputParserTest.php
+++ b/test/Parser/MediaInfoOutputParserTest.php
@@ -11,9 +11,12 @@ class MediaInfoOutputParserTest extends \PHPUnit_Framework_TestCase
      */
     private $outputPath;
 
+    private $invalidOutputPath;
+
     public function setUp()
     {
         $this->outputPath = __DIR__.'/../fixtures/mediainfo-output.xml';
+        $this->invalidOutputPath = __DIR__.'/../fixtures/mediainfo-output-invalid-types.xml';
     }
 
     /**
@@ -47,5 +50,25 @@ class MediaInfoOutputParserTest extends \PHPUnit_Framework_TestCase
 
         $subtitles = $mediaInfoContainer->getSubtitles();
         $this->assertEquals(16, count($subtitles[0]->get()));
+    }
+
+    public function testIgnoreInvalidTrackType()
+    {
+        $mediaInfoOutputParser = new MediaInfoOutputParser();
+        $mediaInfoOutputParser->parse(file_get_contents($this->invalidOutputPath));
+        // the xml specifically has an unknown type in it
+        // when passing true we want to ignore/skip unknown track types
+        $mediaInfoContainer = $mediaInfoOutputParser->getMediaInfoContainer(true);
+    }
+
+    /**
+     * @expectedException UnknownTrackTypeException
+     */
+    public function testThrowInvalidTrackType()
+    {
+        $mediaInfoOutputParser = new MediaInfoOutputParser();
+        $mediaInfoOutputParser->parse(file_get_contents($this->invalidOutputPath));
+        // will throw exception here as default behavior
+        $mediaInfoContainer = $mediaInfoOutputParser->getMediaInfoContainer();
     }
 }

--- a/test/Parser/MediaInfoOutputParserTest.php
+++ b/test/Parser/MediaInfoOutputParserTest.php
@@ -3,7 +3,6 @@
 namespace Mhor\MediaInfo\Test\Parser;
 
 use Mhor\MediaInfo\Parser\MediaInfoOutputParser;
-use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoOutputParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -63,7 +62,7 @@ class MediaInfoOutputParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException UnknownTrackTypeException
+     * @expectedException Mhor\MediaInfo\Exception\UnknownTrackTypeException
      */
     public function testThrowInvalidTrackType()
     {

--- a/test/Parser/MediaInfoOutputParserTest.php
+++ b/test/Parser/MediaInfoOutputParserTest.php
@@ -3,6 +3,7 @@
 namespace Mhor\MediaInfo\Test\Parser;
 
 use Mhor\MediaInfo\Parser\MediaInfoOutputParser;
+use Mhor\MediaInfo\Exception\UnknownTrackTypeException;
 
 class MediaInfoOutputParserTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/fixtures/mediainfo-output-invalid-types.xml
+++ b/test/fixtures/mediainfo-output-invalid-types.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mediainfo version="0.7.69">
+    <File>
+        <track type="General">
+            <Count>284</Count>
+            <Count_of_stream_of_this_kind>1</Count_of_stream_of_this_kind>
+            <Kind_of_stream>General</Kind_of_stream>
+            <Kind_of_stream>General</Kind_of_stream>
+            <Stream_identifier>0</Stream_identifier>
+            <Count_of_audio_streams>1</Count_of_audio_streams>
+            <Audio_Format_List>MPEG Audio</Audio_Format_List>
+            <Audio_Format_WithHint_List>MPEG Audio</Audio_Format_WithHint_List>
+            <Audio_codecs>MPEG-1 Audio layer 3</Audio_codecs>
+            <Complete_name>test.mp3</Complete_name>
+            <File_name>test.mp3</File_name>
+            <File_extension>mp3</File_extension>
+            <Format>MPEG Audio</Format>
+            <Format>MPEG Audio</Format>
+            <Format_Extensions_usually_used>m1a mpa1 mp1 m2a mpa2 mp2 mp3</Format_Extensions_usually_used>
+            <Commercial_name>MPEG Audio</Commercial_name>
+            <Internet_media_type>audio/mpeg</Internet_media_type>
+            <Codec>MPEG Audio</Codec>
+            <Codec>MPEG Audio</Codec>
+            <Codec_Extensions_usually_used>m1a mpa1 mp1 m2a mpa2 mp2 mp3</Codec_Extensions_usually_used>
+            <File_size>19316079</File_size>
+            <File_size>18.4 MiB</File_size>
+            <File_size>18 MiB</File_size>
+            <File_size>18 MiB</File_size>
+            <File_size>18.4 MiB</File_size>
+            <File_size>18.42 MiB</File_size>
+            <Duration>475193</Duration>
+            <Duration>7mn 55s</Duration>
+            <Duration>7mn 55s 193ms</Duration>
+            <Duration>7mn 55s</Duration>
+            <Duration>00:07:55.193</Duration>
+            <Overall_bit_rate_mode>CBR</Overall_bit_rate_mode>
+            <Overall_bit_rate_mode>Constant</Overall_bit_rate_mode>
+            <Overall_bit_rate>320000</Overall_bit_rate>
+            <Overall_bit_rate>320 Kbps</Overall_bit_rate>
+            <Stream_size>308340</Stream_size>
+            <Stream_size>301 KiB (2%)</Stream_size>
+            <Stream_size>301 KiB</Stream_size>
+            <Stream_size>301 KiB</Stream_size>
+            <Stream_size>301 KiB</Stream_size>
+            <Stream_size>301.1 KiB</Stream_size>
+            <Stream_size>301 KiB (2%)</Stream_size>
+            <Proportion_of_this_stream>0.01596</Proportion_of_this_stream>
+            <Title>Track Title</Title>
+            <Album>Album Title</Album>
+            <Album_Performer>Various Artists</Album_Performer>
+            <Track_name>Track Title</Track_name>
+            <Track_name_Position>2</Track_name_Position>
+            <Track_name_Total>2</Track_name_Total>
+            <Performer>Track Artist</Performer>
+            <Recorded_date>2014</Recorded_date>
+            <Cover_Data>sample_binary_cover</Cover_Data>
+            <File_last_modification_date>UTC 2014-12-06 16:43:30</File_last_modification_date>
+            <File_last_modification_date__local_>2014-12-06 17:43:30</File_last_modification_date__local_>
+        </track>
+
+        <track type="Audio">
+            <Count>222</Count>
+            <Count_of_stream_of_this_kind>1</Count_of_stream_of_this_kind>
+            <Kind_of_stream>Audio</Kind_of_stream>
+            <Kind_of_stream>Audio</Kind_of_stream>
+            <Stream_identifier>0</Stream_identifier>
+            <Format>MPEG Audio</Format>
+            <Commercial_name>MPEG Audio</Commercial_name>
+            <Format_version>Version 1</Format_version>
+            <Format_profile>Layer 3</Format_profile>
+            <Internet_media_type>audio/mpeg</Internet_media_type>
+            <Codec>MPA1L3</Codec>
+            <Codec>MPEG-1 Audio layer 3</Codec>
+            <Duration>475611</Duration>
+            <Duration>7mn 55s</Duration>
+            <Duration>7mn 55s 611ms</Duration>
+            <Duration>7mn 55s</Duration>
+            <Duration>00:07:55.611</Duration>
+            <Bit_rate_mode>CBR</Bit_rate_mode>
+            <Bit_rate_mode>Constant</Bit_rate_mode>
+            <Bit_rate>320000</Bit_rate>
+            <Bit_rate>320 Kbps</Bit_rate>
+            <Channel_s_>2</Channel_s_>
+            <Channel_s_>2 channels</Channel_s_>
+            <Sampling_rate>44100</Sampling_rate>
+            <Sampling_rate>44.1 KHz</Sampling_rate>
+            <Samples_count>20974464</Samples_count>
+            <Frame_count>18207</Frame_count>
+            <Compression_mode>Lossy</Compression_mode>
+            <Compression_mode>Lossy</Compression_mode>
+            <Stream_size>19007739</Stream_size>
+            <Stream_size>18.1 MiB (98%)</Stream_size>
+            <Stream_size>18 MiB</Stream_size>
+            <Stream_size>18 MiB</Stream_size>
+            <Stream_size>18.1 MiB</Stream_size>
+            <Stream_size>18.13 MiB</Stream_size>
+            <Stream_size>18.1 MiB (98%)</Stream_size>
+            <Proportion_of_this_stream>0.98404</Proportion_of_this_stream>
+        </track>
+        <track type="Text" streamid="7">
+            <Count>195</Count>
+            <Count_of_stream_of_this_kind>8</Count_of_stream_of_this_kind>
+            <Kind_of_stream>Text</Kind_of_stream>
+            <Kind_of_stream>Text</Kind_of_stream>
+            <Stream_identifier>6</Stream_identifier>
+            <Stream_identifier>7</Stream_identifier>
+            <StreamOrder>9</StreamOrder>
+            <ID>11</ID>
+            <ID>11</ID>
+            <Unique_ID>652628868</Unique_ID>
+            <Format>UTF-8</Format>
+            <Commercial_name>UTF-8</Commercial_name>
+            <Codec_ID>S_TEXT/UTF8</Codec_ID>
+            <Codec_ID_Info>UTF-8 Plain Text</Codec_ID_Info>
+            <Codec>S_TEXT/UTF8</Codec>
+            <Codec>UTF-8</Codec>
+            <Codec_Info>UTF-8 Plain Text</Codec_Info>
+            <Language>ja</Language>
+            <Language>Japanese</Language>
+            <Language>Japanese</Language>
+            <Language>ja</Language>
+            <Language>jpn</Language>
+            <Language>ja</Language>
+            <Default>No</Default>
+            <Default>No</Default>
+            <Forced>No</Forced>
+            <Forced>No</Forced>
+        </track>
+
+        <!-- not a real section, just for testing parsing purposes and throwing exceptions -->
+        <track type="RandomUnknownType" streamid="8">
+            <UnknownAttrib>1</UnknownAttrib>
+            <OtherUnknownAttribStr>test</OtherUnknownAttribStr>
+        </track>
+    </File>
+</Mediainfo>


### PR DESCRIPTION
Added an explicit typed exception to be caught in order to ignore unknown track types. Since you didn't have the Other (or Menu) section types implemented these will just throw exceptions making the library almost useless.

I also implemented the Other type as I wanted to use it. However Menu is still unimplemented, and any other strange sections MediaInfo might have in the future. My suggestion, make it ignore unknown track types by default rather than throw an exception. As you'll see I made the parameters to ignore optional and set to false, so it copies the current behavior.