### PR TITLE
Removed last mb_detect_encoding and fixed bug

### DIFF
--- a/src/Parser/AbstractXmlOutputParser.php
+++ b/src/Parser/AbstractXmlOutputParser.php
@@ -11,10 +11,6 @@ abstract class AbstractXmlOutputParser implements OutputParserInterface
      */
     protected function transformXmlToArray($xmlString)
     {
-        if (mb_detect_encoding($xmlString, 'UTF-8', true) === false) {
-            $xmlString = utf8_encode($xmlString);
-        }
-
         $xml = simplexml_load_string($xmlString);
         $json = json_encode($xml);
 

--- a/src/Parser/MediaInfoOutputParser.php
+++ b/src/Parser/MediaInfoOutputParser.php
@@ -35,6 +35,9 @@ class MediaInfoOutputParser extends AbstractXmlOutputParser
 
         $mediaInfoContainerBuilder = new MediaInfoContainerBuilder($ignoreUnknownTrackTypes);
         $mediaInfoContainerBuilder->setVersion($this->parsedOutput['@attributes']['version']);
+        if (isset($this->parsedOutput['File']['track']['@attributes']['type'])) {
+            $this->parsedOutput['File']['track'] = [$this->parsedOutput['File']['track']];
+        }
 
         foreach ($this->parsedOutput['File']['track'] as $trackType) {
             try {


### PR DESCRIPTION
I've removed the last mb_detect_encoding and fixed a bug (sometimes $this->parsedOutput['File']['track'] is not an array containing the tracks but a track itself).
