### PR TITLE
Fix process call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "symfony/process": "~2.3|~3.0|~4.0",
-        "symfony/filesystem": "~2.3|~3.0|~4.0"
+        "symfony/process": "^3.3|~4.0",
+        "symfony/filesystem": "^3.3|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"
@@ -29,7 +29,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0.x-dev"
+            "dev-master": "5.0.x-dev",
+            "dev-fix-process-call": "4.0.x-dev"
         }
     }
 }

--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -74,8 +74,6 @@ class MediaInfoCommandRunner
     public function run()
     {
         $this->process->run();
-        //var_dump($this->process->getOutput());
-        //exit();
         if (!$this->process->isSuccessful()) {
             throw new \RuntimeException($this->process->getErrorOutput());
         }

--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -46,9 +46,6 @@ class MediaInfoCommandRunner
             $this->arguments = $arguments;
         }
 
-        // /path/to/mediainfo $MEDIAINFO_VAR0 $MEDIAINFO_VAR1...
-        // args are given through ENV vars in order to have system escape them
-
         $args = $this->arguments;
         array_unshift($args, $this->filePath);
 
@@ -57,21 +54,15 @@ class MediaInfoCommandRunner
         ];
         $finalCommand = [$this->command];
 
-        $i = 0;
         foreach ($args as $value) {
-            $var = 'MEDIAINFO_VAR_'.$i++;
-            $finalCommand[] = '$'.$var;
-            $env[$var] = $value;
+            $finalCommand[] = $value;
         }
 
-        $finalCommandString = implode(' ', $finalCommand);
-
         if (null !== $process) {
-            $process->setCommandLine($finalCommandString);
             $process->setEnv($env);
             $this->process = $process;
         } else {
-            $this->process = new Process($finalCommandString, null, $env);
+            $this->process = new Process($finalCommand, null, $env);
         }
     }
 
@@ -83,6 +74,8 @@ class MediaInfoCommandRunner
     public function run()
     {
         $this->process->run();
+        //var_dump($this->process->getOutput());
+        //exit();
         if (!$this->process->isSuccessful()) {
             throw new \RuntimeException($this->process->getErrorOutput());
         }


### PR DESCRIPTION
Symfony Process call with arguments passed via ENV variables fails on Windows resulting in non-meaningful crash "General error". 
I've simplified that call. Symfony\Component\Process\Process::__construct accepts array of cmd and its arguments and it works fine.