### PR TITLE
Wrap every command argument in quotes

### DIFF
--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -71,7 +71,7 @@ class MediaInfoCommandRunner
         $i = 0;
         foreach ($args as $value) {
             $var = 'MEDIAINFO_VAR_'.$i++;
-            $finalCommand[] = '$'.$var;
+            $finalCommand[] = '$"'.$var.'"';
             $env[$var] = $value;
         }
 


### PR DESCRIPTION
When the path to a media file contains spaces (`/path/to/media file.mp3`), the mediainfo command fails (exit code 1).

When using spaces in the filename, the resulting command is: `mediainfo /path/to/media file.mp3 --output=XML -f`. This, of course, fails, because it searches for `/path/to/media` and `file.mp3`.

This can be fixed very simply by wrapping every argument in quotes, so the following command is constructed: ``mediainfo "/path/to/media file.mp3" "--output=XML" "-f"``. The quotes arround `--output=XML` and `-f` don't influence the result.