### PR TITLE
Fix-Runtime exception for version 4.1.1

### DIFF
--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -71,7 +71,7 @@ class MediaInfoCommandRunner
         $i = 0;
         foreach ($args as $value) {
             $var = 'MEDIAINFO_VAR_'.$i++;
-            $finalCommand[] = '$"'.$var.'"';
+            $finalCommand[] = '"$'.$var.'"';
             $env[$var] = $value;
         }
 


### PR DESCRIPTION
Runtime exception for version 4.1.1 due to latest fix - Wrap every command argument in quotes(#86) (Wrong placement of double quotes.)