### PR TITLE
Support for urlencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,20 @@ $mediaInfo->setConfig('command', 'C:\path\to\directory\MediaInfo.exe');
 $mediaInfoContainer = $mediaInfo->getInfo('music.mp3');
 ```
 
+### Urlencode Config
+
+By default MediaInfo tries to detect if a URL is already percent-encode and encodes the URL when it's not.
+Setting the `'urlencode'` config setting to `true` forces MediaInfo to encode the URL despite the presence of percentage signs in the URL.
+This is for example required when using pre-signed URLs for AWS S3 objects.
+
+```php
+$mediaInfo = new MediaInfo();
+$mediaInfo->setConfig('urlencode', true);
+$mediaInfoContainer = $mediaInfo->getInfo('https://demo.us-west-1.amazonaws.com/video.mp4?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ABC%2F123%2Fus-west-1%2Fs3%2Faws4_request&X-Amz-Date=20200721T114451Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Signature=123');
+```
+
+This setting requires MediaInfo `20.03` minimum
+
 ### Symfony integration
 
 Look at this bundle: [MhorMediaInfoBunde](https://github.com/mhor/MhorMediaInfoBundle)

--- a/src/Builder/MediaInfoCommandBuilder.php
+++ b/src/Builder/MediaInfoCommandBuilder.php
@@ -41,7 +41,8 @@ class MediaInfoCommandBuilder
         return new MediaInfoCommandRunner($this->buildMediaInfoProcess(
             $filePath,
             $configuration['command'],
-            $configuration['use_oldxml_mediainfo_output_format']
+            $configuration['use_oldxml_mediainfo_output_format'],
+            $configuration['urlencode'],
         ));
     }
 
@@ -49,10 +50,11 @@ class MediaInfoCommandBuilder
      * @param string      $filePath
      * @param string|null $command
      * @param bool        $forceOldXmlOutput
+     * @param bool        $urlencode
      *
      * @return Process
      */
-    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true): Process
+    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true, bool $urlencode = false): Process
     {
         if ($command === null) {
             $command = MediaInfoCommandRunner::MEDIAINFO_COMMAND;
@@ -67,6 +69,10 @@ class MediaInfoCommandBuilder
 
         if (!$forceOldXmlOutput) {
             $arguments['MEDIAINFO_VAR_OUTPUT'] = MediaInfoCommandRunner::MEDIAINFO_XML_OUTPUT_ARGUMENT;
+        }
+
+        if ($urlencode) {
+            $arguments['MEDIAINFO_VAR_URLENCODE'] = MediaInfoCommandRunner::MEDIAINFO_URLENCODE;
         }
 
         $env = $arguments + [

--- a/src/Builder/MediaInfoCommandBuilder.php
+++ b/src/Builder/MediaInfoCommandBuilder.php
@@ -42,7 +42,7 @@ class MediaInfoCommandBuilder
             $filePath,
             $configuration['command'],
             $configuration['use_oldxml_mediainfo_output_format'],
-            $configuration['urlencode'],
+            $configuration['urlencode']
         ));
     }
 

--- a/src/Builder/MediaInfoCommandBuilder.php
+++ b/src/Builder/MediaInfoCommandBuilder.php
@@ -36,6 +36,7 @@ class MediaInfoCommandBuilder
         $configuration += [
             'command'                            => null,
             'use_oldxml_mediainfo_output_format' => true,
+            'urlencode'                          => false,
         ];
 
         return new MediaInfoCommandRunner($this->buildMediaInfoProcess(

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -103,9 +103,10 @@ class MediaInfo
 
     /**
      * @param $key
-     * @return mixed
      *
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getConfig($key)
     {
@@ -117,4 +118,5 @@ class MediaInfo
 
         return $this->configuration[$key];
     }
+
 }

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -20,6 +20,7 @@ class MediaInfo
     private $configuration = [
         'command'                            => null,
         'use_oldxml_mediainfo_output_format' => true,
+        'urlencode'                          => false,
     ];
 
     /**

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -100,4 +100,21 @@ class MediaInfo
 
         $this->configuration[$key] = $value;
     }
+
+    /**
+     * @param $key
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function getConfig($key)
+    {
+        if (!array_key_exists($key, $this->configuration)) {
+            throw new \Exception(
+                sprintf('key "%s" does\'t exist', $key)
+            );
+        }
+
+        return $this->configuration[$key];
+    }
 }

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -118,5 +118,4 @@ class MediaInfo
 
         return $this->configuration[$key];
     }
-
 }

--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -10,6 +10,7 @@ class MediaInfoCommandRunner
     const MEDIAINFO_OLDXML_OUTPUT_ARGUMENT = '--OUTPUT=OLDXML';
     const MEDIAINFO_XML_OUTPUT_ARGUMENT = '--OUTPUT=XML';
     const MEDIAINFO_FULL_DISPLAY_ARGUMENT = '-f';
+    const MEDIAINFO_URLENCODE = '--urlencode';
 
     /**
      * @var Process

--- a/test/Builder/MediaInfoCommandBuilderTest.php
+++ b/test/Builder/MediaInfoCommandBuilderTest.php
@@ -112,6 +112,7 @@ class MediaInfoCommandBuilderTest extends TestCase
             [
                 'command'                            => '/usr/bin/local/mediainfo',
                 'use_oldxml_mediainfo_output_format' => false,
+                'urlencode'                          => true,
             ]
         );
 
@@ -121,12 +122,14 @@ class MediaInfoCommandBuilderTest extends TestCase
                 $this->filePath,
                 '-f',
                 '--OUTPUT=XML',
+                '--urlencode',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => $this->filePath,
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=XML',
+                'MEDIAINFO_VAR_URLENCODE'    => '--urlencode',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));

--- a/test/MediaInfoTest.php
+++ b/test/MediaInfoTest.php
@@ -35,5 +35,4 @@ class MediaInfoTest extends TestCase
         $mediaInfo = new MediaInfo();
         $mediaInfo->getConfig('unknow_config');
     }
-
 }

--- a/test/MediaInfoTest.php
+++ b/test/MediaInfoTest.php
@@ -12,10 +12,28 @@ class MediaInfoTest extends TestCase
         $mediaInfo = new MediaInfo();
         $mediaInfo->setConfig('command', 'new/mediainfo/path');
 
+        $mediaInfo = new MediaInfo();
+        $this->assertEquals(false, $mediaInfo->getConfig('urlencode'));
+        $mediaInfo->setConfig('urlencode', true);
+        $this->assertEquals(true, $mediaInfo->getConfig('urlencode'));
+
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('key "unknow_config" does\'t exist');
 
         $mediaInfo = new MediaInfo();
         $mediaInfo->setConfig('unknow_config', '');
     }
+
+    public function testGetConfig(): void
+    {
+        $mediaInfo = new MediaInfo();
+        $this->assertEquals(false, $mediaInfo->getConfig('urlencode'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('key "unknow_config" does\'t exist');
+
+        $mediaInfo = new MediaInfo();
+        $mediaInfo->getConfig('unknow_config');
+    }
+
 }


### PR DESCRIPTION
Support the MediaInfo `urlencode` argument. This is for example required when using pre-signed URLs for AWS S3 objects.

Also see https://github.com/MediaArea/MediaInfoLib/issues/221#issuecomment-615178083