### PR TITLE
Add ability to get original parsed XML

### DIFF
--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -24,6 +24,13 @@ class MediaInfo
     ];
 
     /**
+     * Stored original XML output from MediaInfo
+     *
+     * @var string
+     */
+    private $originalXml = '';
+
+    /**
      * @param $filePath
      * @param bool $ignoreUnknownTrackTypes Optional parameter used to skip unknown track types by passing true. The
      *                                      default behavior (false) is throw an exception on unknown track types.
@@ -36,6 +43,8 @@ class MediaInfo
     {
         $mediaInfoCommandBuilder = new MediaInfoCommandBuilder();
         $output = $mediaInfoCommandBuilder->buildMediaInfoCommandRunner($filePath, $this->configuration)->run();
+
+        $this->originalXml = $output;
 
         $mediaInfoOutputParser = new MediaInfoOutputParser();
         $mediaInfoOutputParser->parse($output);
@@ -117,5 +126,15 @@ class MediaInfo
         }
 
         return $this->configuration[$key];
+    }
+
+    /**
+     * Get last received XML output of MediaInfo
+     *
+     * @return string
+     */
+    public function getOriginalXml()
+    {
+        return $this->originalXml;
     }
 }

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -24,7 +24,7 @@ class MediaInfo
     ];
 
     /**
-     * Stored original XML output from MediaInfo
+     * Stored original XML output from MediaInfo.
      *
      * @var string
      */
@@ -129,7 +129,7 @@ class MediaInfo
     }
 
     /**
-     * Get last received XML output of MediaInfo
+     * Get last received XML output of MediaInfo.
      *
      * @return string
      */


### PR DESCRIPTION
Because of #116 I need to have an ability to get to original XML output.

I've tried to put new function into `MediaInfoContainer`, but because of `DumpTrait`'s logic it's not possible to have additional properties there.