### PR TITLE
Add missing raw cover data flag to mediainfo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,31 @@ $mediaInfoContainer = $mediaInfo->getInfo('https://demo.us-west-1.amazonaws.com/
 
 This setting requires MediaInfo `20.03` minimum
 
+### Cover data
+
+Recent versions of MediaInfo don't include cover data by default, without passing an additional flag. To include any available cover data, set the `'include_cover_data'` config setting to `true`. See the [cover type](#cover) for details on retrieving the base64 encoded image from `cover_data`.
+
+Originally this cover data was always included in the MediaInfo output, so this option is unnecessary for older versions. But [around version 18](https://sourceforge.net/p/mediainfo/discussion/297610/thread/aeb4222d/?limit=25) cover data was removed from the output by default, unless you also pass the `--Cover_Data=base64` flag.
+
+```php
+$mediaInfo = new MediaInfo();
+$mediaInfo->setConfig('include_cover_data', true);
+$mediaInfoContainer = $mediaInfo->getInfo('music.mp3');
+
+$general = $mediaInfoContainer->getGeneral();
+if ($general->has('cover_data')) {
+    $attributeCover = $general->get('cover_data');
+    $base64EncodedImage = $attributeCover->getBinaryCover();
+}
+```
+
+**Note:** Older versions of MediaInfo will print the following error if passed this flag:
+
+```bash
+$ mediainfo ./music.mp3 -f --OUTPUT=OLDXML --Cover_Data=base64
+Option not known
+```
+
 ### Symfony integration
 
 Look at this bundle: [MhorMediaInfoBunde](https://github.com/mhor/MhorMediaInfoBundle)

--- a/src/Builder/MediaInfoCommandBuilder.php
+++ b/src/Builder/MediaInfoCommandBuilder.php
@@ -37,13 +37,15 @@ class MediaInfoCommandBuilder
             'command'                            => null,
             'use_oldxml_mediainfo_output_format' => true,
             'urlencode'                          => false,
+            'include_cover_data'                 => true,
         ];
 
         return new MediaInfoCommandRunner($this->buildMediaInfoProcess(
             $filePath,
             $configuration['command'],
             $configuration['use_oldxml_mediainfo_output_format'],
-            $configuration['urlencode']
+            $configuration['urlencode'],
+            $configuration['include_cover_data']
         ));
     }
 
@@ -55,7 +57,7 @@ class MediaInfoCommandBuilder
      *
      * @return Process
      */
-    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true, bool $urlencode = false): Process
+    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true, bool $urlencode = false, bool $includeCoverData = true): Process
     {
         if ($command === null) {
             $command = MediaInfoCommandRunner::MEDIAINFO_COMMAND;
@@ -74,6 +76,10 @@ class MediaInfoCommandBuilder
 
         if ($urlencode) {
             $arguments['MEDIAINFO_VAR_URLENCODE'] = MediaInfoCommandRunner::MEDIAINFO_URLENCODE;
+        }
+
+        if ($includeCoverData) {
+            $arguments['MEDIAINFO_COVER_DATA'] = MediaInfoCommandRunner::MEDIAINFO_INCLUDE_COVER_DATA;
         }
 
         $env = $arguments + [

--- a/src/Builder/MediaInfoCommandBuilder.php
+++ b/src/Builder/MediaInfoCommandBuilder.php
@@ -37,7 +37,7 @@ class MediaInfoCommandBuilder
             'command'                            => null,
             'use_oldxml_mediainfo_output_format' => true,
             'urlencode'                          => false,
-            'include_cover_data'                 => true,
+            'include_cover_data'                 => false,
         ];
 
         return new MediaInfoCommandRunner($this->buildMediaInfoProcess(
@@ -57,7 +57,7 @@ class MediaInfoCommandBuilder
      *
      * @return Process
      */
-    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true, bool $urlencode = false, bool $includeCoverData = true): Process
+    private function buildMediaInfoProcess(string $filePath, string $command = null, bool $forceOldXmlOutput = true, bool $urlencode = false, bool $includeCoverData = false): Process
     {
         if ($command === null) {
             $command = MediaInfoCommandRunner::MEDIAINFO_COMMAND;

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -21,7 +21,7 @@ class MediaInfo
         'command'                            => null,
         'use_oldxml_mediainfo_output_format' => true,
         'urlencode'                          => false,
-        'include_cover_data'                 => true,
+        'include_cover_data'                 => false,
     ];
 
     /**

--- a/src/MediaInfo.php
+++ b/src/MediaInfo.php
@@ -21,6 +21,7 @@ class MediaInfo
         'command'                            => null,
         'use_oldxml_mediainfo_output_format' => true,
         'urlencode'                          => false,
+        'include_cover_data'                 => true,
     ];
 
     /**

--- a/src/Runner/MediaInfoCommandRunner.php
+++ b/src/Runner/MediaInfoCommandRunner.php
@@ -11,6 +11,7 @@ class MediaInfoCommandRunner
     const MEDIAINFO_XML_OUTPUT_ARGUMENT = '--OUTPUT=XML';
     const MEDIAINFO_FULL_DISPLAY_ARGUMENT = '-f';
     const MEDIAINFO_URLENCODE = '--urlencode';
+    const MEDIAINFO_INCLUDE_COVER_DATA = '--Cover_Data=base64';
 
     /**
      * @var Process

--- a/test/Builder/MediaInfoCommandBuilderTest.php
+++ b/test/Builder/MediaInfoCommandBuilderTest.php
@@ -27,12 +27,14 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'https://example.org/',
                 '-f',
                 '--OUTPUT=OLDXML',
+                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => 'https://example.org/',
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
+                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -51,12 +53,14 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'http://example.org/',
                 '-f',
                 '--OUTPUT=OLDXML',
+                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => 'http://example.org/',
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
+                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -91,12 +95,14 @@ class MediaInfoCommandBuilderTest extends TestCase
                 $this->filePath,
                 '-f',
                 '--OUTPUT=OLDXML',
+                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => $this->filePath,
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
+                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -113,6 +119,7 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'command'                            => '/usr/bin/local/mediainfo',
                 'use_oldxml_mediainfo_output_format' => false,
                 'urlencode'                          => true,
+                'include_cover_data'                 => false,
             ]
         );
 

--- a/test/Builder/MediaInfoCommandBuilderTest.php
+++ b/test/Builder/MediaInfoCommandBuilderTest.php
@@ -27,14 +27,12 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'https://example.org/',
                 '-f',
                 '--OUTPUT=OLDXML',
-                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => 'https://example.org/',
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
-                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -53,14 +51,12 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'http://example.org/',
                 '-f',
                 '--OUTPUT=OLDXML',
-                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => 'http://example.org/',
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
-                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -95,14 +91,12 @@ class MediaInfoCommandBuilderTest extends TestCase
                 $this->filePath,
                 '-f',
                 '--OUTPUT=OLDXML',
-                '--Cover_Data=base64',
             ],
             null,
             [
                 'MEDIAINFO_VAR_FILE_PATH'    => $this->filePath,
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=OLDXML',
-                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));
@@ -119,7 +113,7 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'command'                            => '/usr/bin/local/mediainfo',
                 'use_oldxml_mediainfo_output_format' => false,
                 'urlencode'                          => true,
-                'include_cover_data'                 => false,
+                'include_cover_data'                 => true,
             ]
         );
 
@@ -130,6 +124,7 @@ class MediaInfoCommandBuilderTest extends TestCase
                 '-f',
                 '--OUTPUT=XML',
                 '--urlencode',
+                '--Cover_Data=base64',
             ],
             null,
             [
@@ -137,6 +132,7 @@ class MediaInfoCommandBuilderTest extends TestCase
                 'MEDIAINFO_VAR_FULL_DISPLAY' => '-f',
                 'MEDIAINFO_VAR_OUTPUT'       => '--OUTPUT=XML',
                 'MEDIAINFO_VAR_URLENCODE'    => '--urlencode',
+                'MEDIAINFO_COVER_DATA'       => '--Cover_Data=base64',
                 'LANG'                       => 'en_US.UTF-8',
             ]
         ));


### PR DESCRIPTION
It seems like recent builds of `mediainfo` no longer include cover data by default to keep the output size down, but theres a (seemingly undocumented) flag to bring it back: `--Cover_Data=base64`

Found the hidden flag after some googling here: [pymediainfo#51](https://github.com/sbraz/pymediainfo/issues/51) which in turn points here: [sourceforge](https://sourceforge.net/p/mediainfo/discussion/297610/thread/aeb4222d/?limit=25)

I've added an extra `$configuration` option to disable it, but now I'm wondering if it should be off by default rather than on. Even though it seemed to be the default a while back.

Let me know what you think and I'll update the pull request if needs be.