### PR TITLE
Fix generated XML

### DIFF
--- a/src/DumpTrait.php
+++ b/src/DumpTrait.php
@@ -39,11 +39,11 @@ trait DumpTrait
     protected function composeXML($data, &$xml): void
     {
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                if (is_numeric($key)) {
-                    $key = 'item'.$key;
-                }
+            if (is_numeric($key)) {
+                $key = 'item'.$key;
+            }
 
+            if (is_array($value)) {
                 $subnode = $xml->addChild($key);
                 $this->composeXML($value, $subnode);
             } else {


### PR DESCRIPTION
As explain on #116 in some case when ```MediaInfoContainer``` is dump as XML, dumped content could be invalid. 

Prefixing numeric key by 'item' should by done in every case to avoid element name  start by a numeric value.
