### PR TITLE
Exception mediaInfoContainer

### DIFF
--- a/src/Checker/ModeChecker.php
+++ b/src/Checker/ModeChecker.php
@@ -20,7 +20,7 @@ class ModeChecker extends AbstractAttributeChecker
         }
 
         return new Mode(
-            is_array($rateMode[0]) ? implode(" ", $rateMode[0]) : $rateMode[0], 
+            is_array($rateMode[0]) ? implode(' ', $rateMode[0]) : $rateMode[0], 
             is_array($rateMode[1]) ? implode(' ', $rateMode[1]) : $rateMode[1]
         );
     }

--- a/src/Checker/ModeChecker.php
+++ b/src/Checker/ModeChecker.php
@@ -19,7 +19,10 @@ class ModeChecker extends AbstractAttributeChecker
             $rateMode[1] = $rateMode[0];
         }
 
-        return new Mode($rateMode[0], $rateMode[1]);
+        return new Mode(
+            is_array($rateMode[0]) ? implode(" ", $rateMode[0]) : $rateMode[0], 
+            is_array($rateMode[1]) ? implode(" ", $rateMode[1]) : $rateMode[1]
+        );
     }
 
     /**

--- a/src/Checker/ModeChecker.php
+++ b/src/Checker/ModeChecker.php
@@ -21,7 +21,7 @@ class ModeChecker extends AbstractAttributeChecker
 
         return new Mode(
             is_array($rateMode[0]) ? implode(" ", $rateMode[0]) : $rateMode[0], 
-            is_array($rateMode[1]) ? implode(" ", $rateMode[1]) : $rateMode[1]
+            is_array($rateMode[1]) ? implode(' ', $rateMode[1]) : $rateMode[1]
         );
     }
 


### PR DESCRIPTION
In a video, the following instruction generates an exception:

`$mediaInfoContainer = $mediaInfo->getInfo($url);
`

The reason for this is that the Mode class receives an (empty) array as parameter.

This is the log:

```
Mhor\MediaInfo\Attribute\Mode::__construct(): Argument #2 ($fullName) must be of type string, array given, called in /var/app/current/vendor/mhor/php-mediainfo/src/Checker/ModeChecker.php on line 22 {"userId":13,"exception":"[object] (TypeError(code: 0): Mhor\\MediaInfo\\Attribute\\Mode::__construct(): Argument #2 ($fullName) must be of type string, array given, called in /var/app/current/vendor/mhor/php-mediainfo/src/Checker/ModeChecker.php on line 22 at /var/app/current/vendor/mhor/php-mediainfo/src/Attribute/Mode.php:25)
[stacktrace]
#0 /var/app/current/vendor/mhor/php-mediainfo/src/Checker/ModeChecker.php(22): Mhor\\MediaInfo\\Attribute\\Mode->__construct('    0', Array)
#1 /var/app/current/vendor/mhor/php-mediainfo/src/Factory/AttributeFactory.php(27): Mhor\\MediaInfo\\Checker\\ModeChecker->create(Array)
#2 /var/app/current/vendor/mhor/php-mediainfo/src/Builder/MediaInfoContainerBuilder.php(71): Mhor\\MediaInfo\\Factory\\AttributeFactory::create('writing_library', Array)
#3 /var/app/current/vendor/mhor/php-mediainfo/src/Builder/MediaInfoContainerBuilder.php(53): Mhor\\MediaInfo\\Builder\\MediaInfoContainerBuilder->addAttributes(Object(Mhor\\MediaInfo\\Type\\Audio), Array)
#4 /var/app/current/vendor/mhor/php-mediainfo/src/Parser/MediaInfoOutputParser.php(49): Mhor\\MediaInfo\\Builder\\MediaInfoContainerBuilder->addTrackType('Audio', Array)
#5 /var/app/current/vendor/mhor/php-mediainfo/src/MediaInfo.php(44): Mhor\\MediaInfo\\Parser\\MediaInfoOutputParser->getMediaInfoContainer(false)
#6 /var/app/current/app/Http/Controllers/Backend/MediaController.php(103): Mhor\\MediaInfo\\MediaInfo->getInfo('https://d3q5g9h...')
```