### PR TITLE
Fix invalid frame rate for 29.97, 59.94 and other

### DIFF
--- a/src/Attribute/Rate.php
+++ b/src/Attribute/Rate.php
@@ -9,7 +9,7 @@ class Rate implements AttributeInterface
     use DumpTrait;
 
     /**
-     * @var int
+     * @var float
      */
     private $absoluteValue;
 
@@ -24,14 +24,14 @@ class Rate implements AttributeInterface
      */
     public function __construct($absoluteValue, string $textValue)
     {
-        $this->absoluteValue = (int) $absoluteValue;
+        $this->absoluteValue = (float) $absoluteValue;
         $this->textValue = $textValue;
     }
 
     /**
-     * @return int
+     * @return float
      */
-    public function getAbsoluteValue(): int
+    public function getAbsoluteValue(): float
     {
         return $this->absoluteValue;
     }


### PR DESCRIPTION
When a media files with 29.97fps (or 59.97fps or any frame rate with decimal numbers) is parsed the $absoluteValue for media files with 29.97fps will be `29.970` and the $textValue will be `29.970 (30000/1001) FPS`.

The first one would be flattened to number 29 and would lost the precision leading to bugs in applications that would use it. The fix is to cast the value to float value as it was done in version 2.0.